### PR TITLE
Correctly import default get from lodash.get

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { get } from 'lodash.get'
+import get from 'lodash.get'
 import { connect as reduxConnect } from 'react-redux'
 import { call } from 'redux-saga/effects'
 


### PR DESCRIPTION
`lodash.get` exports the get function as its default export. Importing it as though it were an individually exported module (rather than the default) doesn't work–it results in an undefined function error.